### PR TITLE
Update 10.20_二维数组中的查找_对角&二分

### DIFF
--- a/10.20_二维数组中的查找_对角&二分
+++ b/10.20_二维数组中的查找_对角&二分
@@ -23,8 +23,7 @@ public:
 		xhigh = array.size()-1;//行数
 		xmid = (xlow + xhigh) >> 1;
 		//注意low high应该是size-1的问题 避免low=mid+1之后==high进而越界访问
-		while (xlow<xhigh) {//这里xlow<xhigh即可，不要取等于，会导致下界搜索死循环 low=mid=high
-		    //用<可以涵盖的原因是low=high-1的时候 mid=low 如果偏小 low=high=mid+1 这时下面正好进行了==的判断
+		while (xlow<xhigh) {		
 			ylow = 0, yhigh = array[xmid].size()-1;//列数
 			ymid = (ylow + yhigh) >> 1;
 			while (ylow<yhigh) {
@@ -46,10 +45,24 @@ public:
 			}
 			xmid = (xlow + xhigh) >> 1;
 		}
+		//****注意：由于是二维数组，这里low=high的情况还需要搜索这一行
+		ylow = 0, yhigh = array[xmid].size() - 1;//列数
+		ymid = (ylow + yhigh) >> 1;
+		while (ylow<yhigh) {
+			if (array[xmid][ymid] == target) return 1;
+			else if (array[xmid][ymid]>target) {
+				yhigh = ymid;
+			}
+			else if (array[xmid][ymid]<target) {
+				ylow = ymid + 1;
+			}
+			ymid = (ylow + yhigh) >> 1;
+		}
 		if (array[xmid][ymid] == target) return 1;
 		else return 0;
 	}
 };
+
 
 int main() {
 	vector<vector<int> > test(5);


### PR DESCRIPTION
0-对于其中的一行，ylow=yhigh的时候，跳出循环，但是紧接着的array[xmid][ymid]中ymid=ylow=yhigh，对行完成了完全的检测
1-但是对于二维数组，当行数xlow=xhigh的时候，这一行的搜索仅仅有判断array[xmid][ymid]一个元素，而其他的size-1个数字被跳过了，所以需要在跳出循环的时候补充搜索这一行